### PR TITLE
Update Mednafen version and fix Homebrew installer URL

### DIFF
--- a/installMednafenMac.sh
+++ b/installMednafenMac.sh
@@ -34,7 +34,7 @@ export CC=/usr/local/Cellar/gcc48/4.8.3/bin/gcc-4.8
 export CPP=/usr/local/Cellar/gcc48/4.8.3/bin/cpp-4.8
 export CXX=/usr/local/Cellar/gcc48/4.8.3/bin/c++-4.8
 
-ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew update && brew upgrade
 brew tap homebrew/versions
 brew install gcc48 wget libcdio libsndfile sdl

--- a/installMednafenMac.sh
+++ b/installMednafenMac.sh
@@ -21,7 +21,7 @@
 # <http://www.gnu.org/licenses/>.
 
 
-VERSION=${VERSION:-0.9.36.3}
+VERSION=${VERSION:-0.9.36.4}
 
 ## script to automatically install mednafen on mac os
 #


### PR DESCRIPTION
1. Upgrade Mednafen from 0.9.36.3 to 0.9.36.4
2. Fix Homebrew installer URL.  Note that if you run the script as-is you get the following message:

> Whoops, the Homebrew installer has moved! Please instead run:
> 
> ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
> 
> Also, please ask wherever you got this link from to update it to the above.
> Thanks!
